### PR TITLE
added minimal buggy example

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -50,6 +50,9 @@
   "sound_fft": {
     "tabs": []
   },
+  "sound_fft_minimal": {
+    "tabs": []
+  },
   "scrabble": {
     "tabs": []
   },

--- a/src/bundles/sound_fft_minimal/functions.ts
+++ b/src/bundles/sound_fft_minimal/functions.ts
@@ -1,0 +1,5 @@
+import {
+  playFFT
+} from '../sound/functions';
+  
+export function hello_world(): void {}

--- a/src/bundles/sound_fft_minimal/index.ts
+++ b/src/bundles/sound_fft_minimal/index.ts
@@ -1,0 +1,3 @@
+export {
+  hello_world
+} from './functions';

--- a/src/bundles/sound_fft_minimal/types.ts
+++ b/src/bundles/sound_fft_minimal/types.ts
@@ -1,0 +1,1 @@
+// nothing


### PR DESCRIPTION
# Description

Added minimal example of issue "Error(s) occurred when executing the module"

Minimal Source code to reproduce the error:

```
import {hello_world} from "sound_fft_minimal";
```
