### PR TITLE
Added direct conversions between Sound and FrequencyList in sound_fft

### DIFF
--- a/src/bundles/sound_fft/index.ts
+++ b/src/bundles/sound_fft/index.ts
@@ -15,6 +15,6 @@ export {
   get_magnitude,
   get_phase,
 
-  frequency_to_time,
-  time_to_frequency
+  frequency_to_sound,
+  sound_to_frequency
 } from './functions';

--- a/src/bundles/sound_fft/sound_functions.ts
+++ b/src/bundles/sound_fft/sound_functions.ts
@@ -1,0 +1,56 @@
+import {
+  head,
+  tail,
+  pair,
+  is_pair
+} from 'js-slang/dist/stdlib/list';
+import { type Sound, type Wave } from '../sound/types';
+
+export function is_sound(x: any): x is Sound {
+  return (
+    is_pair(x)
+        && typeof get_wave(x) === 'function'
+        && typeof get_duration(x) === 'number'
+  );
+}
+
+/**
+ * Makes a Sound with given wave function and duration.
+ * The wave function is a function: number -> number
+ * that takes in a non-negative input time and returns an amplitude
+ * between -1 and 1.
+ *
+ * @param wave wave function of the Sound
+ * @param duration duration of the Sound
+ * @return with wave as wave function and duration as duration
+ * @example const s = make_sound(t => Math_sin(2 * Math_PI * 440 * t), 5);
+ */
+export function make_sound(wave: Wave, duration: number): Sound {
+  if (duration < 0) {
+    throw new Error('Sound duration must be greater than or equal to 0');
+  }
+
+  return pair((t: number) => (t >= duration ? 0 : wave(t)), duration);
+}
+
+/**
+ * Accesses the wave function of a given Sound.
+ *
+ * @param sound given Sound
+ * @return the wave function of the Sound
+ * @example get_wave(make_sound(t => Math_sin(2 * Math_PI * 440 * t), 5)); // Returns t => Math_sin(2 * Math_PI * 440 * t)
+ */
+export function get_wave(sound: Sound): Wave {
+  return head(sound);
+}
+
+/**
+ * Accesses the duration of a given Sound.
+ *
+ * @param sound given Sound
+ * @return the duration of the Sound
+ * @example get_duration(make_sound(t => Math_sin(2 * Math_PI * 440 * t), 5)); // Returns 5
+ */
+export function get_duration(sound: Sound): number {
+  return tail(sound);
+}

--- a/src/bundles/sound_fft/types.ts
+++ b/src/bundles/sound_fft/types.ts
@@ -1,6 +1,7 @@
-import type { Pair } from 'js-slang/dist/stdlib/list';
+import type { Pair, List } from 'js-slang/dist/stdlib/list';
 
 export type TimeSamples = Array<number>;
 export type FrequencySample = Pair<number, number>;
 export type FrequencySamples = Array<FrequencySample>;
+export type FrequencyList = List;
 export type Filter = (freq: FrequencySamples) => FrequencySamples;


### PR DESCRIPTION
# Description

- Added definition for FrequencyList type.
- Added public methods `sound_to_frequency` and `frequency_to_sound` for direct conversion between Sound and FrequencyList types.
- Copied the functions `next_power_of_2` and `sound_to_time_samples` from `sound` module into `sound_fft` module. Hopefully they can be deleted from `sound` module eventually.
- Added `sound_fft/sound_functions.ts` to allow `sound_fft` to use some select functions from `sound`, as there are still issues with importing.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
