### PR TITLE
Added frequency augmentation

### DIFF
--- a/src/bundles/plotly/functions.ts
+++ b/src/bundles/plotly/functions.ts
@@ -4,11 +4,11 @@
  */
 
 import context from 'js-slang/context';
-import Plotly, { type Data, type Layout } from 'plotly.js-dist';
 import { list_to_vector } from 'js-slang/dist/stdlib/list';
+import Plotly, { type Data, type Layout } from 'plotly.js-dist';
 import { type Sound } from '../sound/types';
 import type {
-  FrequencySample,
+  AugmentedSample,
   FrequencyList,
 } from '../sound_fft/types';
 import { generatePlot } from './curve_functions';
@@ -477,12 +477,12 @@ export const draw_sound_frequency_2d = (frequencies: FrequencyList) => {
 
   const x_s: number[] = [];
   const y_s: number[] = [];
-  const frequencies_arr: FrequencySample[] = list_to_vector(frequencies);
+  const frequencies_arr: AugmentedSample[] = list_to_vector(frequencies);
   const len: number = frequencies_arr.length;
 
   for (let i = 0; i < len; i += 1) {
     const bin_freq: number = i * FS / len;
-    const sample: FrequencySample = frequencies_arr[i];
+    const sample: AugmentedSample = frequencies_arr[i];
     const magnitude: number = get_magnitude(sample);
 
     x_s.push(bin_freq);

--- a/src/bundles/plotly/sound_functions.ts
+++ b/src/bundles/plotly/sound_functions.ts
@@ -4,7 +4,7 @@ import {
   is_pair
 } from 'js-slang/dist/stdlib/list';
 import { type Sound, type Wave } from '../sound/types';
-import { type FrequencySample } from '../sound_fft/types';
+import { type FrequencySample, type AugmentedSample } from '../sound_fft/types';
 export function is_sound(x: any): x is Sound {
   return (
     is_pair(x)
@@ -38,6 +38,15 @@ export function get_duration(sound: Sound): number {
  * @param frequency_sample given frequency sample
  * @return the magnitude of the frequency sample
  */
-export function get_magnitude(frequency_sample: FrequencySample): number {
+function get_magnitude_fs(frequency_sample: FrequencySample): number {
   return head(frequency_sample);
+}
+/**
+ * Accesses the magnitude of a given augmented sample.
+ *
+ * @param augmented_sample given augmented sample
+ * @return the magnitude of the augmented sample
+ */
+export function get_magnitude(augmented_sample: AugmentedSample): number {
+  return get_magnitude_fs(tail(augmented_sample));
 }

--- a/src/bundles/sound/index.ts
+++ b/src/bundles/sound/index.ts
@@ -60,9 +60,5 @@ export {
   stop,
   triangle_sound,
   trombone,
-  violin,
-  sound_to_time_samples,
-  play_samples_in_tab,
-  play_samples,
-  //play_filtered
+  violin
 } from './functions';

--- a/src/bundles/sound_fft/index.ts
+++ b/src/bundles/sound_fft/index.ts
@@ -14,6 +14,8 @@ export {
 
   get_magnitude,
   get_phase,
+  get_frequency,
+  make_augmented_sample,
 
   frequency_to_sound,
   sound_to_frequency,

--- a/src/bundles/sound_fft/types.ts
+++ b/src/bundles/sound_fft/types.ts
@@ -2,6 +2,7 @@ import type { Pair, List } from 'js-slang/dist/stdlib/list';
 
 export type TimeSamples = Array<number>;
 export type FrequencySample = Pair<number, number>;
+export type AugmentedSample = Pair<number, FrequencySample>;
 export type FrequencySamples = Array<FrequencySample>;
-export type FrequencyList = List;
+export type FrequencyList = List; // containing AugmentedSample
 export type Filter = (freq: FrequencyList) => FrequencyList;


### PR DESCRIPTION
# Description

**Current issue: `sound_to_frequency` (and probably other methods too) don't work when the sound is too long**

`sound_fft`
- Added `AugmentedSample` type: pair of number (frequency) and FrequencySample
- Modified `FrequencyList` type to list of AugmentedSample (previously list of FrequencySample)
- Added `make_augmented_sample` and `get_frequency` (of AugmentedSample) methods
- Modified existing methods to use the new types

`plotly`
- Modified `sound_functions.ts` and the `draw_sound_frequency_2d` method to use the new types

`sound`
- Removed methods and imports that are no longer needed

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
